### PR TITLE
adding WS_EX_TRANSPARENT and WS_EX_LAYERED

### DIFF
--- a/Windowing.cs
+++ b/Windowing.cs
@@ -560,6 +560,8 @@ namespace FMUtils.WinApi
         public const UInt32 WS_EX_CLIENTEDGE = 0x0200;
         public const UInt32 WS_EX_OVERLAPPEDWINDOW = (WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE);
         public const UInt32 WS_EX_DLGMODALFRAME = 0x01;
+        public const UInt32 WS_EX_TRANSPARENT = 0x20;
+        public const UInt32 WS_EX_LAYERED = 0x80000
 
         public const uint GA_PARENT = 1;
         public const uint GA_ROOT = 2;

--- a/Windowing.cs
+++ b/Windowing.cs
@@ -561,7 +561,7 @@ namespace FMUtils.WinApi
         public const UInt32 WS_EX_OVERLAPPEDWINDOW = (WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE);
         public const UInt32 WS_EX_DLGMODALFRAME = 0x01;
         public const UInt32 WS_EX_TRANSPARENT = 0x20;
-        public const UInt32 WS_EX_LAYERED = 0x80000
+        public const UInt32 WS_EX_LAYERED = 0x80000;
 
         public const uint GA_PARENT = 1;
         public const uint GA_ROOT = 2;


### PR DESCRIPTION
they are required to turn windows click-through and to hide them from alt-tab
